### PR TITLE
Fix dark mode toggle on tools page

### DIFF
--- a/src/pages/AITools.tsx
+++ b/src/pages/AITools.tsx
@@ -282,168 +282,171 @@ const AITools: React.FC = () => {
     }
   };
 
-  return (
-   <motion.div
-  initial={{ opacity: 0 }}
-  animate={{ opacity: 1 }}
-  exit={{ opacity: 0 }}
-  transition={{ duration: 0.8 }}
-  className="min-h-screen px-6 py-12 bg-gradient-to-b from-gray-900 via-gray-950 to-black"
->
-  <div className="container mx-auto max-w-7xl">
+ return (
     <motion.div
-      initial={{ y: 50, opacity: 0 }}
-      animate={{ y: 0, opacity: 1 }}
-      transition={{ delay: 0.2, duration: 0.8 }}
-      className="text-center mb-16"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.8 }}
+      className="min-h-screen px-6 py-12 bg-white dark:bg-gray-900"
     >
-      <h1 className="text-6xl font-extrabold mb-6 bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 bg-clip-text text-transparent drop-shadow-lg">
-        AI Tools
-      </h1>
-      <p className="text-xl text-gray-300 max-w-2xl mx-auto leading-relaxed">
-        Harness the power of AI with our comprehensive suite of tools
-      </p>
-    </motion.div>
+      <div className="container mx-auto max-w-7xl">
+        <motion.div
+          initial={{ y: 50, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          transition={{ delay: 0.2, duration: 0.8 }}
+          className="text-center mb-16"
+        >
+          <h1 className="text-6xl font-extrabold mb-6 bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 bg-clip-text text-transparent drop-shadow-lg">
+            AI Tools
+          </h1>
+          <p className="text-xl text-gray-700 dark:text-gray-300 max-w-2xl mx-auto leading-relaxed">
+            Harness the power of AI with our comprehensive suite of tools
+          </p>
+        </motion.div>
 
-    <motion.div
-      initial={{ y: 30, opacity: 0 }}
-      animate={{ y: 0, opacity: 1 }}
-      transition={{ delay: 0.4, duration: 0.8 }}
-      className="relative mb-12"
-    >
-      <Search className="absolute left-5 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-      <input
-        type="text"
-        placeholder="Search AI tools..."
-        value={searchTerm}
-        onChange={(e) => setSearchTerm(e.target.value)}
-        className="w-full pl-14 pr-4 py-4 bg-gray-800/70 backdrop-blur-md border border-gray-700 rounded-2xl text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300"
-      />
-    </motion.div>
+        <motion.div
+          initial={{ y: 30, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          transition={{ delay: 0.4, duration: 0.8 }}
+          className="relative mb-12"
+        >
+          <Search className="absolute left-5 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
+          <input
+            type="text"
+            placeholder="Search AI tools..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-full pl-14 pr-4 py-4 bg-gray-100 dark:bg-gray-800/70 backdrop-blur-md border border-gray-300 dark:border-gray-700 rounded-2xl text-gray-800 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300"
+          />
+        </motion.div>
 
-    <div className="grid lg:grid-cols-3 gap-10">
-      <div className="lg:col-span-1">
-        <div className="grid gap-4">
-          {filteredTools.map((tool, index) => (
-            <motion.div
-              key={tool.id}
-              initial={{ x: -50, opacity: 0 }}
-              animate={{ x: 0, opacity: 1 }}
-              transition={{ delay: 0.6 + index * 0.1, duration: 0.8 }}
-              onClick={() => setSelectedTool(tool.id)}
-              className={`p-6 rounded-2xl cursor-pointer shadow-lg transition-all duration-300 transform hover:scale-105 ${
-                selectedTool === tool.id
-                  ? "bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-blue-500/50"
-                  : "bg-gray-800/70 backdrop-blur-md border border-gray-700 hover:border-blue-500"
-              }`}
-            >
-              <div className="flex items-center space-x-4">
-                <div
-                  className={`w-12 h-12 rounded-full flex items-center justify-center ${
+        <div className="grid lg:grid-cols-3 gap-10">
+          <div className="lg:col-span-1">
+            <div className="grid gap-4">
+              {filteredTools.map((tool, index) => (
+                <motion.div
+                  key={tool.id}
+                  initial={{ x: -50, opacity: 0 }}
+                  animate={{ x: 0, opacity: 1 }}
+                  transition={{ delay: 0.6 + index * 0.1, duration: 0.8 }}
+                  onClick={() => setSelectedTool(tool.id)}
+                  className={`p-6 rounded-2xl cursor-pointer shadow-lg transition-all duration-300 transform hover:scale-105 ${
                     selectedTool === tool.id
-                      ? "bg-white/20"
-                      : "bg-gradient-to-r from-blue-600 to-purple-600"
+                      ? "bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-blue-500/50"
+                      : "bg-gray-100 dark:bg-gray-800/70 backdrop-blur-md border border-gray-300 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-500"
                   }`}
                 >
-                  <tool.icon className="w-6 h-6 text-white" />
-                </div>
-                <div>
-                  <h3 className="text-lg font-semibold">{tool.name}</h3>
-                  <p
-                    className={`text-sm ${
-                      selectedTool === tool.id
-                        ? "text-gray-200"
-                        : "text-gray-400"
-                    }`}
-                  >
-                    {tool.description}
-                  </p>
-                </div>
-              </div>
-            </motion.div>
-          ))}
-        </div>
-      </div>
-
-      <div className="lg:col-span-2">
-        <motion.div
-          initial={{ x: 50, opacity: 0 }}
-          animate={{ x: 0, opacity: 1 }}
-          transition={{ delay: 0.8, duration: 0.8 }}
-          className="bg-gray-800/70 backdrop-blur-lg p-10 rounded-2xl border border-gray-700 h-full shadow-lg"
-        >
-          {selectedTool ? (
-            <div>
-              <h2 className="text-3xl font-bold mb-6 text-gradient">
-                {tools.find((t) => t.id === selectedTool)?.name}
-              </h2>
-
-              <div className="space-y-6">
-                <div>
-                  <label className="block text-sm font-medium mb-3 text-gray-300">
-                    Input
-                  </label>
-                  <textarea
-                    value={input}
-                    onChange={(e) => setInput(e.target.value)}
-                    placeholder={
-                      tools.find((t) => t.id === selectedTool)?.placeholder
-                    }
-                    className="w-full h-32 p-4 bg-gray-900/60 border border-gray-600 rounded-xl text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
-                  />
-                </div>
-
-                <button
-                  onClick={handleSubmit}
-                  disabled={loading}
-                  className="w-full px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 rounded-xl font-semibold text-white shadow-lg hover:from-blue-700 hover:to-purple-700 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {loading ? "Processing..." : "Generate Result"}
-                </button>
-
-                {output && (
-                  <div>
-                    <label className="block text-sm font-medium mb-3 text-gray-300">
-                      Output
-                    </label>
-                    <FormattedOutput content={output} onClear={() => setOutput("")} />
-                  </div>
-                )}
-                {imageUrl && (
-                  <div>
-                    <label className="block text-sm font-medium mb-3 text-gray-300">
-                      Output
-                    </label>
-                    <div className="p-4 bg-gray-900/60 border border-gray-600 rounded-xl">
-                      <img
-                        src={imageUrl}
-                        alt="Generated Image"
-                        className="rounded-lg shadow-lg"
-                      />
+                  <div className="flex items-center space-x-4">
+                    <div
+                      className={`w-12 h-12 rounded-full flex items-center justify-center ${
+                        selectedTool === tool.id
+                          ? "bg-white/20"
+                          : "bg-gradient-to-r from-blue-600 to-purple-600"
+                      }`}
+                    >
+                      <tool.icon className="w-6 h-6 text-white" />
+                    </div>
+                    <div>
+                      <h3 className={`text-lg font-semibold ${selectedTool === tool.id ? "text-white" : "text-gray-900 dark:text-white"}`}>
+                        {tool.name}
+                      </h3>
+                      <p
+                        className={`text-sm ${
+                          selectedTool === tool.id
+                            ? "text-gray-200"
+                            : "text-gray-600 dark:text-gray-400"
+                        }`}
+                      >
+                        {tool.description}
+                      </p>
                     </div>
                   </div>
-                )}
-              </div>
+                </motion.div>
+              ))}
             </div>
-          ) : (
-            <div className="flex items-center justify-center h-full">
-              <div className="text-center">
-                <div className="w-20 h-20 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4 shadow-lg">
-                  <Zap className="w-10 h-10 text-white" />
-                </div>
-                <h3 className="text-2xl font-semibold mb-2">Select an AI Tool</h3>
-                <p className="text-gray-400">
-                  Choose a tool from the left to get started
-                </p>
-              </div>
-            </div>
-          )}
-        </motion.div>
-      </div>
-    </div>
-  </div>
-</motion.div>
+          </div>
 
+          <div className="lg:col-span-2">
+            <motion.div
+              initial={{ x: 50, opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              transition={{ delay: 0.8, duration: 0.8 }}
+              className="bg-gray-100 dark:bg-gray-800/70 backdrop-blur-lg p-10 rounded-2xl border border-gray-300 dark:border-gray-700 h-full shadow-lg"
+            >
+              {selectedTool ? (
+                <div>
+                  <h2 className="text-3xl font-bold mb-6 text-gray-900 dark:text-white">
+                    {tools.find((t) => t.id === selectedTool)?.name}
+                  </h2>
+
+                  <div className="space-y-6">
+                    <div>
+                      <label className="block text-sm font-medium mb-3 text-gray-600 dark:text-gray-300">
+                        Input
+                      </label>
+                      <textarea
+                        value={input}
+                        onChange={(e) => setInput(e.target.value)}
+                        placeholder={
+                          tools.find((t) => t.id === selectedTool)?.placeholder
+                        }
+                        className="w-full h-32 p-4 bg-gray-200 dark:bg-gray-900/60 border border-gray-300 dark:border-gray-600 rounded-xl text-gray-800 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                      />
+                    </div>
+
+                    <button
+                      onClick={handleSubmit}
+                      disabled={loading}
+                      className="w-full px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 rounded-xl font-semibold text-white shadow-lg hover:from-blue-700 hover:to-purple-700 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {loading ? "Processing..." : "Generate Result"}
+                    </button>
+
+                    {output && (
+                      <div>
+                        <label className="block text-sm font-medium mb-3 text-gray-600 dark:text-gray-300">
+                          Output
+                        </label>
+                        <FormattedOutput content={output} onClear={() => setOutput("")} />
+                      </div>
+                    )}
+                    {imageUrl && (
+                      <div>
+                        <label className="block text-sm font-medium mb-3 text-gray-600 dark:text-gray-300">
+                          Output
+                        </label>
+                        <div className="p-4 bg-gray-200 dark:bg-gray-900/60 border border-gray-300 dark:border-gray-600 rounded-xl">
+                          <img
+                            src={imageUrl}
+                            alt="Generated Image"
+                            className="rounded-lg shadow-lg"
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center justify-center h-full">
+                  <div className="text-center">
+                    <div className="w-20 h-20 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4 shadow-lg">
+                      <Zap className="w-10 h-10 text-white" />
+                    </div>
+                    <h3 className="text-2xl font-semibold text-gray-900 dark:text-white mb-2">
+                      Select an AI Tool
+                    </h3>
+                    <p className="text-gray-600 dark:text-gray-400">
+                      Choose a tool from the left to get started
+                    </p>
+                  </div>
+                </div>
+              )}
+            </motion.div>
+          </div>
+        </div>
+      </div>
+    </motion.div>
   );
 };
 


### PR DESCRIPTION
**Description:**
This PR fixes an issue where the Tools page was not toggling correctly between light and dark themes.

Close issue: #26 

**Changes Made:**

* Added missing `dark:` classes to the Tools page container for proper dark mode styling.
* Ensured background and text colors match the rest of the app’s dark mode scheme.

**Before:**

* Tools page always displayed in light mode, even when dark mode was enabled.

**After:**

* Tools page now respects the dark mode setting and updates UI accordingly.

**Demo Video**

https://github.com/user-attachments/assets/1881c296-ee57-4d78-9c68-048d97f6e583

