### PR TITLE
Fix Scroll Position Issue on Page Navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import AITools from './pages/AITools';
 import Chatbot from './components/Chatbot';
 import { initGA, trackPageView } from './utils/analytics';
 import { Toaster } from 'react-hot-toast';
+import ScrollToTop from './components/ScrollToTop';
 
 // Create a separate component for analytics tracking
 const AnalyticsTracker: React.FC = () => {
@@ -52,6 +53,7 @@ function App() {
       <Router>
         <AnalyticsTracker />
         <div className="min-h-screen bg-gray-900 text-white overflow-hidden">
+          <ScrollToTop />
           <AnimatePresence mode="wait">
             <Layout>
               <Routes>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
## Description:
This PR resolves the issue where navigating to a new page from the sidebar or navigation links would open the new page at the bottom, instead of starting from the top.

## Related Issue:
Fixes: #33 

## Changes Made:

- Added a ScrollToTop component that ensures the page scrolls to the top whenever the route changes.
- Implemented window.scrollTo(0,0) logic inside the routing lifecycle.
- Integrated the ScrollToTop component into the project’s routing setup.

## Screenshots:
### Before:
<img width="1892" height="906" alt="478927445-1cb45b79-020f-4afa-b675-05d592aa0b77" src="https://github.com/user-attachments/assets/378ed709-233f-4f41-aecd-d94a737a7659" />

### After:
<img width="1890" height="952" alt="image" src="https://github.com/user-attachments/assets/23a4f303-647b-4c5f-941c-ff65342e33c3" />

## Testing:

- Verified on Windows 10, Chrome Version 139.0.7258.128 (64-bit).
- Tested across multiple pages to confirm consistent behavior.

## Additional Notes:
This fix improves user experience by ensuring navigation feels smooth and predictable.
Closes issue #33 
Please Merge this PR. @Jyotibrat 

