### PR TITLE
Fix blog card hover in dark mode and make card clickable

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -109,39 +109,48 @@ const Blog: React.FC = () => {
     ) : (
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
         {filteredPosts.map((post, index) => (
-          <motion.article
+          <a
             key={post.id}
-            initial={{ y: 50, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ delay: 0.6 + index * 0.1, duration: 0.8 }}
-            className="bg-gray-100 dark:bg-gray-800/50 backdrop-blur-sm p-6 rounded-xl border border-gray-300 dark:border-gray-700 hover:border-blue-500 transition-all duration-300 transform hover:scale-105"
+            href={post.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block"
           >
-            <h2 className="text-xl font-semibold mb-3 text-gray-900 dark:text-white line-clamp-2">
-              {post.title}
-            </h2>
-            <div className="flex items-center space-x-4 mb-4 text-sm text-gray-500 dark:text-gray-400">
-              <div className="flex items-center space-x-1">
-                <Calendar className="w-4 h-4" />
-                <span>{formatDate(post.published)}</span>
-              </div>
-              <div className="flex items-center space-x-1">
-                <User className="w-4 h-4" />
-                <span>{post.author}</span>
-              </div>
-            </div>
-            <a
-              href={post.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center space-x-2 text-blue-500 dark:text-blue-400 hover:text-blue-600 dark:hover:text-blue-300 transition-colors duration-300"
+            <motion.article
+              initial={{ y: 50, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ delay: 0.6 + index * 0.1, duration: 0.8 }}
+              className="bg-gray-100 dark:bg-gray-800/50 backdrop-blur-sm p-6 rounded-xl 
+                        border border-gray-300 dark:border-gray-700 
+                        hover:border-blue-500 dark:hover:border-blue-500 
+                        transition-all duration-300 transform hover:scale-105 cursor-pointer"
             >
-              <span>Read More</span>
-              <ExternalLink className="w-4 h-4" />
-            </a>
-          </motion.article>
+              <h2 className="text-xl font-semibold mb-3 text-gray-900 dark:text-white line-clamp-2">
+                {post.title}
+              </h2>
+
+              <div className="flex items-center space-x-4 mb-4 text-sm text-gray-500 dark:text-gray-400">
+                <div className="flex items-center space-x-1">
+                  <Calendar className="w-4 h-4" />
+                  <span>{formatDate(post.published)}</span>
+                </div>
+                <div className="flex items-center space-x-1">
+                  <User className="w-4 h-4" />
+                  <span>{post.author}</span>
+                </div>
+              </div>
+
+              <div className="inline-flex items-center space-x-2 text-blue-500 dark:text-blue-400 
+                               transition-colors duration-300">
+                <span>Read More</span>
+                <ExternalLink className="w-4 h-4" />
+              </div>
+            </motion.article>
+          </a>
         ))}
       </div>
     )}
+
 
     {!loading && filteredPosts.length === 0 && (
       <motion.div


### PR DESCRIPTION
Close issue: #36 

### Description

This PR improves the **Blog Cards** by addressing two issues:

* ✅ **Hover Fix**: The border hover color now works correctly in both **light** and **dark** modes.
* ✅ **Clickable Card**: The entire blog card is now clickable, improving the UX and making navigation more intuitive.

---

### Changes Made

* Updated `src/pages/Blog.tsx`:

  * Fixed dark mode hover style (`hover:border-blue-500` works consistently).
  * Wrapped blog card content with an anchor to make the full card clickable.

---

### Demo Video

[**Note**: In this video, the blog title not appearing is not a bug — it was due to my blogspot blogs setup. Everything works fine in the actual implementation.]

https://github.com/user-attachments/assets/d5e831ef-bfd0-4b12-a4c9-b60c4ae3c92c

---

### Checklist

* [x] Fixes dark mode hover bug
* [x] Improves UX by making cards clickable
* [x] Tested in both light & dark mode
* [x] No breaking changes introduced

---

@Jyotibrat, plz review my PR
