### PR TITLE
fix: Changed position of dark/light toggle button at the right to remove overlapping of text #27 issue

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -53,7 +53,7 @@ const [theme, setTheme] = useState(localStorage.getItem('theme') || 'dark');
       {/* Theme Toggle Button */}
       <button
         onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-        className="fixed top-3 right-3 z-50 p-2 bg-gray-200 dark:bg-gray-800 text-black dark:text-white rounded-lg"
+        className="fixed top-3 right-8 z-50 p-2 bg-gray-200 dark:bg-gray-800 text-black dark:text-white rounded-lg"
       >
         {theme === 'light' ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
       </button>


### PR DESCRIPTION
this was an important issue as earlier both button and ai tools text not visible properly
this is the screenshot of proper positioned button
<img width="1358" height="1297" alt="AI-Flow-09-04-2025_12_45_AM" src="https://github.com/user-attachments/assets/e0e22f85-7f19-419f-a111-97bd228dea97" />
